### PR TITLE
Make parentEntity optional in Typescript

### DIFF
--- a/src/core/entity.d.ts
+++ b/src/core/entity.d.ts
@@ -6,7 +6,7 @@ export interface ECSYThreeObject3D {
 }
 
 export class ECSYThreeEntity extends _Entity {
-  addObject3DComponent(obj: Object3D, parentEntity: Entity): this
+  addObject3DComponent(obj: Object3D, parentEntity?: Entity): this
   removeObject3DComponent(unparent: boolean): void
   remove(forceImmediate: boolean): void
   getObject3D<T extends Object3D>(): T & ECSYThreeObject3D


### PR DESCRIPTION
Right now creating an entity requires a parent in typescript, clearly just a bug since there is a nullcheck on parent in entity.js