### PR TITLE
Handle returning undefined from getObject3D and upgrade to new ecsy PropType defs

### DIFF
--- a/src/core/Object3DComponent.d.ts
+++ b/src/core/Object3DComponent.d.ts
@@ -1,12 +1,10 @@
-import { Component, PropType } from "ecsy";
+import { Component, RefPropType } from "ecsy";
 import { Object3D } from "three";
 
-interface Object3DComponentProps {
-  value: Object3D
-}
+export class Object3DComponent extends Component<Object3DComponent> {
+  value: Object3D | null;
 
-export class Object3DComponent extends Component<Object3DComponentProps> {
   static schema: {
-    value: { default: null, type: PropType<any> }
+    value: { default: null, type: RefPropType<Object3D> }
   };
 }

--- a/src/core/Object3DComponent.d.ts
+++ b/src/core/Object3DComponent.d.ts
@@ -2,9 +2,9 @@ import { Component, RefPropType } from "ecsy";
 import { Object3D } from "three";
 
 export class Object3DComponent extends Component<Object3DComponent> {
-  value: Object3D | null;
+  value?: Object3D;
 
   static schema: {
-    value: { default: null, type: RefPropType<Object3D> }
+    value: { type: RefPropType<Object3D> }
   };
 }

--- a/src/core/Object3DComponent.js
+++ b/src/core/Object3DComponent.js
@@ -3,5 +3,5 @@ import { Component, Types } from "ecsy";
 export class Object3DComponent extends Component {}
 
 Object3DComponent.schema = {
-  value: { default: null, type: Types.Ref }
+  value: { type: Types.Ref }
 };

--- a/src/core/Types.d.ts
+++ b/src/core/Types.d.ts
@@ -1,10 +1,10 @@
 import { Vector3 } from "three";
 import { PropType } from "ecsy";
 
-export const Vector3Type: PropType<Vector3>;
+export type Vector3Type = PropType<Vector3, Vector3>;
 
 export const ThreeTypes: {
-  Vector3Type: PropType<Vector3>
+  Vector3: Vector3Type
 };
 
 export { Types } from "ecsy";

--- a/src/core/Types.js
+++ b/src/core/Types.js
@@ -1,15 +1,13 @@
 import { Vector3 } from "three";
 import { createType, copyCopyable, cloneClonable } from "ecsy";
 
-export const Vector3Type = createType({
-  name: "Vector3",
-  default: new Vector3(),
-  copy: copyCopyable,
-  clone: cloneClonable
-});
-
 export const ThreeTypes = {
-  Vector3Type
+  Vector3: createType({
+    name: "Vector3",
+    default: new Vector3(),
+    copy: copyCopyable,
+    clone: cloneClonable
+  })
 };
 
 export { Types } from "ecsy";

--- a/src/core/entity.d.ts
+++ b/src/core/entity.d.ts
@@ -9,5 +9,5 @@ export class ECSYThreeEntity extends _Entity {
   addObject3DComponent(obj: Object3D, parentEntity?: Entity): this
   removeObject3DComponent(unparent?: boolean): void
   remove(forceImmediate?: boolean): void
-  getObject3D<T extends Object3D>(): (T & ECSYThreeObject3D) | null
+  getObject3D?<T extends Object3D>(): T & ECSYThreeObject3D
 }

--- a/src/core/entity.d.ts
+++ b/src/core/entity.d.ts
@@ -9,5 +9,5 @@ export class ECSYThreeEntity extends _Entity {
   addObject3DComponent(obj: Object3D, parentEntity?: Entity): this
   removeObject3DComponent(unparent?: boolean): void
   remove(forceImmediate?: boolean): void
-  getObject3D<T extends Object3D>(): T & ECSYThreeObject3D
+  getObject3D<T extends Object3D>(): (T & ECSYThreeObject3D) | null
 }

--- a/src/core/entity.js
+++ b/src/core/entity.js
@@ -38,6 +38,7 @@ export class ECSYThreeEntity extends _Entity {
   }
 
   getObject3D() {
-    return this.getComponent(Object3DComponent).value;
+    const component = this.getComponent(Object3DComponent);
+    return component && component.value;
   }
 }


### PR DESCRIPTION
- https://github.com/MozillaReality/ecsy/pull/208 adds new PropType definitions, this PR brings ecsy-three up to date with those.
- `getObject3D`  now properly handles a missing `Object3DComponent` and the return type is now optional