### PR TITLE
Fix getSystem, export ECSYThreeEntity Type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,6 @@
-export { ECSYThreeWorld } from "./world";
-export { ECSYThreeSystem } from "./system";
+export * from "./world";
+export * from "./system";
+export * from "./entity";
 export * as ThreeTypes from "./types/index";
 export * from "./components/index";
 export * from "./systems/index";

--- a/src/world.d.ts
+++ b/src/world.d.ts
@@ -3,7 +3,7 @@ import { ECSYThreeEntity } from "./entity.js";
 import { ECSYThreeSystem } from "./system.js";
 
 export class ECSYThreeWorld extends World {
-  getSystem<S extends System>(System: SystemConstructor<S>): ECSYThreeSystem
+  getSystem<S extends System>(System: SystemConstructor<S>): S
   getSystems(): Array<ECSYThreeSystem>
   createEntity(name?: string): ECSYThreeEntity;
 }


### PR DESCRIPTION
`getSystem` was broken with the latest version of ECSY and we should export `ECSYThreeEntity`'s type so that you can use it in component property definitions.