### PR TITLE
Prevent double removeEntity call caused by obj.traverse

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -147,7 +147,9 @@ export class ECSYThreeEntity extends _Entity {
       const obj = this.getObject3D();
       obj.traverse((o) => {
         if (o.entity) {
-          this._entityManager.removeEntity(o.entity, forceImmediate);
+          if (o !== obj) {
+            this._entityManager.removeEntity(o.entity, forceImmediate);
+          }
         }
         o.entity = null;
       });

--- a/src/entity.js
+++ b/src/entity.js
@@ -147,15 +147,15 @@ export class ECSYThreeEntity extends _Entity {
       const obj = this.getObject3D();
       obj.traverse((o) => {
         if (o.entity) {
-          if (o !== obj) {
-            this._entityManager.removeEntity(o.entity, forceImmediate);
-          }
+          this._entityManager.removeEntity(o.entity, forceImmediate);
         }
         o.entity = null;
       });
       obj.parent && obj.parent.remove(obj);
     }
-    this._entityManager.removeEntity(this, forceImmediate);
+    else {
+      this._entityManager.removeEntity(this, forceImmediate);
+    }
   }
 
   getObject3D() {


### PR DESCRIPTION
https://github.com/MozillaReality/ecsy-three/issues/28

Prevents removeEntity from being called two times when remove is called on an entity.