### PR TITLE
Fix getObject3D return type

### DIFF
--- a/src/entity.d.ts
+++ b/src/entity.d.ts
@@ -9,5 +9,5 @@ export class ECSYThreeEntity extends _Entity {
   addObject3DComponent(obj: Object3D, parentEntity?: Entity): this
   removeObject3DComponent(unparent?: boolean): void
   remove(forceImmediate?: boolean): void
-  getObject3D?<T extends Object3D>(): T & ECSYThreeObject3D
+  getObject3D<T extends Object3D>(): (T & ECSYThreeObject3D) | undefined
 }


### PR DESCRIPTION
The `getObject3D` function was marked optional instead of its return type.