### PR TITLE
implement Rotating.speed field in the spinning-cube demo

### DIFF
--- a/examples/spinning-cube.js
+++ b/examples/spinning-cube.js
@@ -16,8 +16,9 @@ class RotationSystem extends System {
   execute(delta) {
     this.queries.entities.results.forEach((entity) => {
       var rotation = entity.getObject3D().rotation;
-      rotation.x += 0.5 * delta;
-      rotation.y += 0.1 * delta;
+      var speed = entity.getComponent(Rotating).speed
+      rotation.x += 0.5 * delta * speed;
+      rotation.y += 0.1 * delta * speed;
     });
   }
 }
@@ -47,5 +48,5 @@ const mesh = new Mesh(
 
 world
   .createEntity()
-  .addComponent(Rotating)
+  .addComponent(Rotating,{speed:0.7})
   .addObject3DComponent(mesh, sceneEntity);


### PR DESCRIPTION
The spinning-cube demo creates a Rotate component with a speed field, which is then left out of the corresponding system. Implementing this demonstrates how custom components can be set and used by systems.